### PR TITLE
Option to assign themes during guided site creation

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -9,7 +9,7 @@ import color from 'picocolors';
 
 import { haxIntro, communityStatement, log } from "./lib/statements.js";
 import { webcomponentProcess, webcomponentCommandDetected } from "./lib/programs/webcomponent.js";
-import { siteActions, siteNodeOperations, siteProcess, siteCommandDetected } from "./lib/programs/site.js";
+import { siteActions, siteNodeOperations, siteProcess, siteCommandDetected, siteThemeList } from "./lib/programs/site.js";
 import { camelToDash } from "./lib/utils.js";
 import * as hax from "@haxtheweb/haxcms-nodejs";
 const HAXCMS = hax.HAXCMS;
@@ -386,6 +386,15 @@ async function main() {
                   initialValue: author,
                 });
               }
+            },
+            theme: async({ results }) => {
+              let themes = await siteThemeList();
+              return p.select({
+                message: "Theme:",
+                required: false,
+                options: themes,
+                initialValue: themes[0]
+              })
             },
             extras: ({ results }) => {
               if (!commandRun.options.auto && commandRun.options.i) {

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -915,7 +915,7 @@ export async function siteProcess(commandRun, project, port = '3000') {    // au
       "site": {
           "name": project.name,
           "description": "own course",
-          "theme": commandRun.options.theme ? commandRun.options.theme : "clean-one"
+          "theme": commandRun.options.theme ? commandRun.options.theme : (project.theme ? project.theme : "clean-one") 
       },
       "build": {
           "type": "own",


### PR DESCRIPTION
## New Features
* Simple theme selector implemented within the `hax start` creation menu
* Pulls list of available themes from `haxcms-nodejs` data
* If CLI arguments aren't used, `siteProcess` function now pushes chosen theme from menu to `site.json`
## Related Issues
* haxtheweb/issues#2170
* haxtheweb/issues#2169
