### PR TITLE
Linux + macOS (hopefully) Manual support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,18 @@ Commands:
   help [command]                 display help for command
 ```
 
-## Site  context
+## Manual
+
+### Linux / macOS
+
+Run `man hax` to get detailed manual.
+
+## Site context
 - listing stats
 - launch site
 - publish to surge.sh (if installed)
 
-## web component context
+## Web component context
 - launch element
 
 # Alternative Usage
@@ -83,7 +89,6 @@ npm init @haxtheweb
   "scripts": {
     "hax": "hax"
   }
-}
 ```
 
 ```bash
@@ -93,6 +98,15 @@ npm run hax -- --name my-element --y
 
 ## Windows problems?
 Try setting a different cache path to load from `npm config set cache C:\tmp\nodejs\npm-cache --global`
+
+If you wish to use PowerShell over Command Prompt, you may need to change your execution policy to allow scripts using the `Set-ExecutionPolicy` command with the `-ExecutionPolicy` and `-Scope` parameters. You should **not** need to do this if you are using Command Prompt.
+
+```powershell
+# To see your current execution policy
+Get-ExecutionPolicy
+```
+
+`Set-ExecutionPolicy` command documentation: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.4
 
 Follow the prompts and let's HAX the Web together!
 

--- a/docs/hax.1
+++ b/docs/hax.1
@@ -1,13 +1,15 @@
-.TH HAX\-CREATE 1 hax
+.TH HAX\-CREATE 1 hax 9.0.18 "HAX COMMAND INTERFACE MANUAL"
 
 .SH NAME
-hax \- a tool to create HAX websites and web components
+hax \- a tool to create HAX websites and web components quickly.
 
 .SH SYNOPSIS
 hax [options] [command]
 
 .SH DESCRIPTION
-Create HAX based web components and websites.
+HAX seeks to be the smallest possible back-end CMS to make HAX work and be able to build websites with it. Leveraging JSON Outline Schema, HAX is able to author multiple pages, which it then writes onto the file system. This way a slim server layer is just for basic authentication, knowing how to save files, and placing them in version control.
+
+This command line tool can be used to create and modify two different HAX based file structures. Web components (essentially custom HTML tags) using Lit or HAX Single-Sites (a single website editable in the browser with the CMS tools)
 
 .SH COMMANDS
 .PP
@@ -31,13 +33,13 @@ Verbose output
 \--debug
 Output for developers
 .TP
-\--format [char]
+\--format [format]
 Output format\; json (default), yaml
 .TP
-\--path [char]
+\--path [path]
 Where to perform operation
 .TP
-\--npm\-client [char]
+\--npm\-client [client]
 NPM client to use (must be installed); npm (default), yarn, pnpm
 .TP
 \--y, \--auto
@@ -55,58 +57,58 @@ Prevent interactions / sub\-process, good for scripting
 \--to\-file [char]
 Redirect command output to a file
 .TP
-\--org [char]
+\--org [organization]
 Organization for package.json
 .TP
-\--author [char]
+\--author [author]
 Author for site / package.json
 .TP
 \--writeHaxProperties
 Write haxProperties for the element
 .TP
-\--import\-site [char]
+\--import\-site [url]
 URL of site to import
 .TP
-\--import\-structure [char]
+\--import\-structure [method]
 Import method to use: pressbooksToSite | elsmlnToSite | haxcmsToSite | notionToSite | gitbookToSite | evolutionToSite | htmlToSite | docxToSite
 .TP
-\--node\-op [char]
+\--node\-op [operation]
 Node operation to perform
 .TP
-\--item\-id [char]
+\--item\-id [id]
 Node ID to operate on
 .TP
-\--name [char]
+\--name [name]
 Name of the project
 .TP
-\--domain [char]
+\--domain [name]
 Published domain name
 .TP
 \--items\-import [char]
 Import items from a file / site
 .TP
-\--title [char]
+\--title [title]
 Title
 .TP
-\--content [char]
+\--content [content]
 Page content
 .TP
-\--slug [char]
+\--slug [slug]
 Path (slug)
 .TP
-\--published [char]
+\--published [status]
 Publishing status
 .TP
-\--tags [char]
+\--tags [tag]
 Tags
 .TP
-\--parent [char]
+\--parent [parent]
 Parent
 .TP
-\--order [char]
+\--order [order]
 Order
 .TP
-\--theme [char]
+\--theme [theme]
 Theme
 .TP
 \--hide\-in\-menu [char]
@@ -115,8 +117,21 @@ Hide in menu
 \-h, \--help
 Display help for command
 
+.SH EXAMPLES
+.TP
+.B hax start
+Navigatable interface
+.TP
+.B hax webcomponent my-element --y
+Make a new HAX capable, i18n wired, design system (DDD) driven web component
+.TP
+.B hax site mysite --y
+Create a new HAXsite (HAXcms, single site) 
+
 .SH BUGS
 Bugs can be viewed at GitHub Issues: https://github.com/haxtheweb/issues/issues
+
+Bugs can also be submitted through Merlin on a HAX Site (in the browser) by typing "Issue" to jump start a report!
 
 .SH EXTRA
 .PP

--- a/docs/hax.1
+++ b/docs/hax.1
@@ -40,7 +40,7 @@ Where to perform operation
 \--npm\-client [char]
 NPM client to use (must be installed); npm (default), yarn, pnpm
 .TP
-\--y, --auto
+\--y, \--auto
 Yes to all questions
 .TP
 \--skip
@@ -82,7 +82,7 @@ Name of the project
 \--domain [char]
 Published domain name
 .TP
-\--items-import [char]
+\--items\-import [char]
 Import items from a file / site
 .TP
 \--title [char]

--- a/docs/hax.1
+++ b/docs/hax.1
@@ -1,0 +1,138 @@
+.TH HAX\-CREATE 1 hax
+
+.SH NAME
+hax \- a tool to create HAX websites and web components
+
+.SH SYNOPSIS
+hax [options] [command]
+
+.SH DESCRIPTION
+Create HAX based web components and websites.
+
+.SH COMMANDS
+.PP
+.B start
+\- Interactive program to pick options
+.PP
+.B site
+[options] [action] \- Create a HAX website
+.PP
+.B webcomponent
+[options] [name] \- Create Lit based web components, with HAX recommendations
+.PP
+.B help
+[command] \- Display help for command
+
+.SH OPTIONS
+.TP
+\--v
+Verbose output
+.TP
+\--debug
+Output for developers
+.TP
+\--format [char]
+Output format\; json (default), yaml
+.TP
+\--path [char]
+Where to perform operation
+.TP
+\--npm\-client [char]
+NPM client to use (must be installed); npm (default), yarn, pnpm
+.TP
+\--y, --auto
+Yes to all questions
+.TP
+\--skip
+Skip extras (e.g. animations) in tool
+.TP
+\--quiet
+Remove console logging
+.TP
+\--no\-i
+Prevent interactions / sub\-process, good for scripting
+.TP
+\--to\-file [char]
+Redirect command output to a file
+.TP
+\--org [char]
+Organization for package.json
+.TP
+\--author [char]
+Author for site / package.json
+.TP
+\--writeHaxProperties
+Write haxProperties for the element
+.TP
+\--import\-site [char]
+URL of site to import
+.TP
+\--import\-structure [char]
+Import method to use: pressbooksToSite | elsmlnToSite | haxcmsToSite | notionToSite | gitbookToSite | evolutionToSite | htmlToSite | docxToSite
+.TP
+\--node\-op [char]
+Node operation to perform
+.TP
+\--item\-id [char]
+Node ID to operate on
+.TP
+\--name [char]
+Name of the project
+.TP
+\--domain [char]
+Published domain name
+.TP
+\--items-import [char]
+Import items from a file / site
+.TP
+\--title [char]
+Title
+.TP
+\--content [char]
+Page content
+.TP
+\--slug [char]
+Path (slug)
+.TP
+\--published [char]
+Publishing status
+.TP
+\--tags [char]
+Tags
+.TP
+\--parent [char]
+Parent
+.TP
+\--order [char]
+Order
+.TP
+\--theme [char]
+Theme
+.TP
+\--hide\-in\-menu [char]
+Hide in menu
+.TP
+\-h, \--help
+Display help for command
+
+.SH BUGS
+Bugs can be viewed at GitHub Issues: https://github.com/haxtheweb/issues/issues
+
+.SH EXTRA
+.PP
+.B Website: 
+https://haxtheweb.org/
+.PP
+.B CLI Repository: 
+https://github.com/haxtheweb/create
+.PP
+.B Web Components Repository:
+https://github.com/haxtheweb/webcomponents
+
+.SH AUTHORS
+.PP
+.B CLI Contributors:
+https://github.com/haxtheweb/create/graphs/contributors
+.PP
+.B Web Components Contributors:
+https://github.com/haxtheweb/webcomponents/graphs/contributors

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "dev": "nodemon --watch src",
     "haxcms-nodejs": "haxcms-nodejs"
   },
+  "man": [
+    "./docs/hax.1"
+  ],
   "bin": {
     "create-haxtheweb": "./dist/create.js",
     "hax": "./dist/create.js"


### PR DESCRIPTION
It's the end of the semester, I await graduation, and yet time moves slower, so I present you this documentation that I can use to amplify my portfolio \\(ˆ˚ˆ)/  

PR essentially adds a manual for `hax` command on Linux (tested) and macOS (untested) devices. Cannot test Command Prompt or PowerShell at the moment because they seem to hate locally installed NPM packages, so if this gets approved then I can update and test for Windows manual support at a later time. I plan to continue working on this manual to make sure it looks consistent and gets improved descriptions and anything else it needs, just wanted to get it pulled into the main repo to test Windows stuff along with getting it out there since it is more or less "content complete".

## Context if you don't know
Linux (and I think macOS) have support for the `man` command, which will open a manual in the terminal for whatever command you put after `man`. For example, typing `man ls` will list the manual for the `ls` command, showing all the flags and other fancy options that can be used, and is meant to be a more in-depth set of instructions than a --help flag.

## What this adds
* Synopsis showing how to lay out a `hax` command
* Description detailing what HAX is, and what the CLI can do
* Options pulled from the `--help` flag, with slight modifications to be a bit more detailed
* Example commands pulled from the README.md file
* Instructions detailing how to report bugs via the HAX GitHub Issues Queue
* Links to the haxtheweb.org site, CLI repository, and web components repository (to encourage people to check them out and possibly contribute)
* Authors links connecting to the GitHub contributor graphs for the CLI and Web Components repos (waaaay easier than updating names manually).
* Additions to README detailing how to fix some possible PowerShell issues when running `hax` command, mainly based around `ExecutionPolicy`.
* `man` field in package.json which tells `man` command where to find the manual file for `hax`.

## What it looks like on my terminal (WSL)
![{91AB79B8-3BC4-42DE-BA29-010D3E599438}](https://github.com/user-attachments/assets/f2e2ed8a-b3ee-4bad-96bd-9c0f2c04af14)

## "It WoRkS oN mY mAcHiNe!"
Also can confirm this works with local installation (`npm install -g .`) in root project folder, then running `man hax`, which is how I got the screenshot above.
![machone](https://github.com/user-attachments/assets/c35256e1-528a-4945-8982-4608c932fbff)

