### PR TITLE
Adjusted site:theme action to accept CLI input

### DIFF
--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 
 import * as p from '@clack/prompts';
 import * as ejs from "ejs";
-import color from 'picocolors';
+import color from 'picocolsite:theors';
 import { dump, load } from 'js-yaml';
 import * as winston from 'winston';
 
@@ -731,12 +731,12 @@ export async function siteCommandDetected(commandRun) {
                 initialValue: val,
                 options: list,
               });
-              let themes = await HAXCMS.getThemes();
-              if (themes && commandRun.options.theme && themes[commandRun.options.theme]) {
-                activeHaxsite.manifest.metadata.theme = themes[commandRun.options.theme];
-                activeHaxsite.manifest.save(false);
-                recipe.log(siteLoggingName, commandString(commandRun));
-              }
+            }
+            let themes = await HAXCMS.getThemes();
+            if (themes && commandRun.options.theme && themes[commandRun.options.theme]) {
+              activeHaxsite.manifest.metadata.theme = themes[commandRun.options.theme];
+              activeHaxsite.manifest.save(false);
+              recipe.log(siteLoggingName, commandString(commandRun));
             }
           }
           catch(e) {

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 
 import * as p from '@clack/prompts';
 import * as ejs from "ejs";
-import color from 'picocolsite:theors';
+import color from 'picocolors';
 import { dump, load } from 'js-yaml';
 import * as winston from 'winston';
 


### PR DESCRIPTION
## New Features/Changes
* The `site:theme` action has been tweaked to apply CLI input from a `--theme` argument.
* Example: `hax site site:theme --theme "polaris-flex-theme"`

## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2023