### PR TITLE
cli: Input validation and Commander.js scripting with themes

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -62,7 +62,7 @@ async function main() {
   .option('--items-import <char>', 'import items from a file / site')
   .option('--recipe <char>', 'path to recipe file')
   .option('--custom-theme-name <char>', 'custom theme name')
-  .option('--custom-theme-template <char>', 'custom theme template')
+  .option('--custom-theme-template <char>', 'custom theme template; (options: base, polaris-flex, polaris-sidebar)')
   .version(await HAXCMS.getHAXCMSVersion())
   .helpCommand(true);
 
@@ -122,7 +122,7 @@ async function main() {
   .option('--item-import <char>', 'import items from a file / site')
   .option('--recipe <char>', 'path to recipe file')
   .option('--custom-theme-name <char>', 'custom theme name')
-  .option('--custom-theme-template <char>', 'custom theme template')
+  .option('--custom-theme-template <char>', 'custom theme template (options: base, polaris-flex, polaris-sidebar)')
   .version(await HAXCMS.getHAXCMSVersion());
   let siteNodeOps = siteNodeOperations();
   for (var i in siteNodeOps) {

--- a/src/templates/sitetheme/base-theme.js
+++ b/src/templates/sitetheme/base-theme.js
@@ -14,7 +14,7 @@ import { html, css, HAXCMSLitElementTheme } from "@haxtheweb/haxcms-elements/lib
  *  - HAXCMSTheme - A super class that provides correct baseline wiring to build a new theme
  *
  * @demo demo/index.html
- * @element <%= customName %>
+ * @element <%= customThemeName %>
  */
 class <%= className %> extends HAXCMSLitElementTheme {
   //styles function
@@ -34,7 +34,7 @@ class <%= className %> extends HAXCMSLitElementTheme {
    * @notice function name must be here for tooling to operate correctly
    */
   static get tag() {
-    return "<%= customName %>";
+    return "<%= customThemeName %>";
   }
  
   constructor() {

--- a/src/templates/sitetheme/flex-theme.js
+++ b/src/templates/sitetheme/flex-theme.js
@@ -16,7 +16,7 @@ import "@haxtheweb/haxcms-elements/lib/ui-components/blocks/site-children-block.
  *  - HAXCMSTheme - A super class that provides correct baseline wiring to build a new theme
  *
  * @demo demo/index.html
- * @element <%= customName %>
+ * @element <%= customThemeName %>
  */
 class <%= className %> extends PolarisFlexTheme {
   //styles function
@@ -55,7 +55,7 @@ class <%= className %> extends PolarisFlexTheme {
    * @notice function name must be here for tooling to operate correctly
    */
   static get tag() {
-    return "<%= customName %>";
+    return "<%= customThemeName %>";
   }
  
   constructor() {

--- a/src/templates/sitetheme/sidebar-theme.js
+++ b/src/templates/sitetheme/sidebar-theme.js
@@ -16,7 +16,7 @@ import "@haxtheweb/haxcms-elements/lib/ui-components/blocks/site-children-block.
  *  - HAXCMSTheme - A super class that provides correct baseline wiring to build a new theme
  *
  * @demo demo/index.html
- * @element <%= customName %>
+ * @element <%= customThemeName %>
  */
 class <%= className %> extends PolarisFlexTheme {
   //styles function
@@ -101,7 +101,7 @@ class <%= className %> extends PolarisFlexTheme {
    * @notice function name must be here for tooling to operate correctly
    */
   static get tag() {
-    return "<%= customName %>";
+    return "<%= customThemeName %>";
   }
  
   constructor() {


### PR DESCRIPTION
## New Features
* Added CLI options for `--custom-theme-name` and `--custom-theme-template` to Commander.js
* `hax-create` will throw an error if the options are scripted without `--theme custom-theme`
* `Clack` prompts will validate if the theme name is already part of the HAX core themes, has valid formatting, etc.
* Refactored the `customSiteTheme` function in `siteProcess` to respond to either `commandRun` or `project` inputs
* `customSiteTheme` uses some regex to apply our naming requirements (`custom-${name}-theme`) before deploying the webcomponent
## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2196
* https://github.com/haxtheweb/issues/issues/2023