### PR TITLE
Some DX improvements from over Spring Break

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -375,14 +375,17 @@ async function main() {
       activeProject = project.type;
       // silly but this way we don't have to take options for quitting
       if (project.type !== 'quit') {
-        // also silly temp spot
-        let themes = await siteThemeList();
-        const custom = {
-          value: 'custom-theme',
-          label: 'Create Custom Theme',
-        }
-        // Append custom option to list of core themes
-        themes.push(custom);
+        // global spot for core themes list
+        const coreThemes = [
+          { value: 'clean-one', label: 'Clean One' },
+          { value: 'clean-two', label: 'Clean Two' },
+          { value: 'clean-portfolio-theme', label: 'Clean Portfolio' },
+          { value: 'haxor-slevin', label: 'Haxor Blog' },
+          { value: 'polaris-flex-theme', label: 'Polaris - Flex' },
+          { value: 'polaris-flex-sidebar', label: 'Polaris - Flex Sidebar' },
+          { value: 'polaris-invent-theme', label: 'Polaris - Invent' },
+          { value: 'custom-theme', label: 'Create Custom Theme' }
+        ]
 
         project = await p.group(
           {
@@ -523,19 +526,19 @@ async function main() {
               if (results.type === "site" && !commandRun.options.theme) {
                 // support having no theme but autoselecting
                 if (commandRun.options.auto && commandRun.options.skip) {
-                  commandRun.options.theme = themes[0].value;
+                  commandRun.options.theme = coreThemes[0].value;
                 }
                 else {
                   return p.select({
                     message: "Theme:",
                     required: false,
-                    options: themes,
-                    initialValue: themes[0]
+                    options: coreThemes,
+                    initialValue: coreThemes[0]
                   })  
                 }
               }
               else if (results.type === "site" && commandRun.options.theme) {
-                if (themes.filter((item => item.value === commandRun.options.theme)).length === 0) {
+                if (coreThemes.filter((item => item.value === commandRun.options.theme)).length === 0) {
                   program.error(color.red('Theme is not in the list of valid themes'));
                   process.exit(1);
                 }
@@ -551,7 +554,7 @@ async function main() {
                     if (!value) {
                       return "Theme name is required (tab writes default)";
                     }
-                    if(themes.some(theme => theme.value === value)) {
+                    if(coreThemes.some(theme => theme.value === value)) {
                       return "Theme name is already in use";
                     }
                     if (/^\d/.test(value)) {
@@ -573,7 +576,7 @@ async function main() {
                 if (!value) {
                   program.error(color.red("Theme name is required (tab writes default)"));
                 }
-                if(themes.some(theme => theme.value === value)) {
+                if(coreThemes.some(theme => theme.value === value)) {
                   program.error(color.red("Theme name is already in use"));
                 }
                 if (/^\d/.test(value)) {

--- a/src/create.js
+++ b/src/create.js
@@ -571,8 +571,8 @@ async function main() {
                 return tmpCustomName;
               }
               else if (results.type === "site") {
-                // need to validate theme
-                let value = results.name;
+                // need to validate theme from CLI arguments
+                let value = `${commandRun.options.customThemeName ? commandRun.options.customThemeName : (results.name ? results.name : commandRun.arguments.action)}`;
                 if (!value) {
                   program.error(color.red("Theme name is required (tab writes default)"));
                 }

--- a/src/create.js
+++ b/src/create.js
@@ -545,7 +545,7 @@ async function main() {
               if (results.theme === "custom-theme") {
                 let tmpCustomName = await p.text({
                   message: 'Theme Name:',
-                  placeholder: `${results.name}`,
+                  placeholder: `custom-${commandRun.arguments.action ? commandRun.arguments.action : results.name}-theme`,
                   required: false,
                   validate: (value) => {
                     if (!value) {

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -1259,7 +1259,7 @@ async function customSiteTheme(commandRun, project) {
   // validate start and end tags for theme name
   if(/^custom/.test(project.customThemeName) && !/^custom-/.test(project.customThemeName)){
     project.customThemeName = project.customThemeName.replace(/^custom/, "custom-");
-  } else if (!/^custom-/.test(project.className)) {
+  } else if (!/^custom-/.test(project.customThemeName)) {
     project.customThemeName = `custom-${project.customThemeName}`;
   }
 


### PR DESCRIPTION
## New Features
* **Create.js**
    * Prompts now feature a smaller, curated list of core HAX themes. This should reduce visual overload and focuses on our best offerings.
    * The `customThemeName` placeholder correctly pulls the project name from Commander.js arguments. For example, `hax site my-place`.
    * Added a ternary check to the `customThemeName` validations in case `results.name` does not exist.
* **Site.js**
    * Fixed an incorrect variable in the regex checks for `customSiteTheme()`. Previously theme names that already had the custom tag would be output as `custom-custom-my-place-theme`.
## Related Issues
* https://github.com/haxtheweb/issues/issues/2236
* https://github.com/haxtheweb/issues/issues/2196