### PR TITLE
cli: Custom theme support on existing HAX sites

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -376,16 +376,7 @@ async function main() {
       // silly but this way we don't have to take options for quitting
       if (project.type !== 'quit') {
         // global spot for core themes list
-        const coreThemes = [
-          { value: 'clean-one', label: 'Clean One' },
-          { value: 'clean-two', label: 'Clean Two' },
-          { value: 'clean-portfolio-theme', label: 'Clean Portfolio' },
-          { value: 'haxor-slevin', label: 'Haxor Blog' },
-          { value: 'polaris-flex-theme', label: 'Polaris - Flex' },
-          { value: 'polaris-flex-sidebar', label: 'Polaris - Flex Sidebar' },
-          { value: 'polaris-invent-theme', label: 'Polaris - Invent' },
-          { value: 'custom-theme', label: 'Create Custom Theme' }
-        ]
+        let coreThemes = await siteThemeList(true);
 
         project = await p.group(
           {

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -1206,6 +1206,9 @@ export async function siteProcess(commandRun, project, port = '3000') {    // au
   });
   // matching the common object elsewhere tho different reference in this command since it creates from nothing
   // capture this if use input on the fly
+  if(!commandRun.arguments.action){
+    commandRun.arguments.action = project.name;
+  }
   commandRun.options.theme = project.theme;
   recipe.log(siteLoggingName, commandString(commandRun));
   if (commandRun.options.v) {

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -731,8 +731,10 @@ export async function siteCommandDetected(commandRun) {
                 initialValue: val,
                 options: list,
               });
+            }
 
-              if (commandRun.options.theme === "custom-theme"){
+            if (commandRun.options.theme === "custom-theme"){
+              if(!commandRun.options.customThemeName) {
                 commandRun.options.customThemeName = await p.text({
                   message: 'Theme Name:',
                   placeholder: `custom-${activeHaxsite.name}-theme`,
@@ -755,7 +757,9 @@ export async function siteCommandDetected(commandRun) {
                     }
                   }
                 })
+              }
 
+              if (!commandRun.options.customThemeTemplate) {
                 const options = [
                   { value: 'base', label: 'Vanilla Theme with Hearty Documentation' },
                   { value: 'polaris-flex', label: 'Minimalist Theme with Horizontal Nav' },
@@ -770,6 +774,7 @@ export async function siteCommandDetected(commandRun) {
                 })
               }
             }
+
             let themes = await HAXCMS.getThemes();
 
             if (themes && commandRun.options.theme) {

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -568,7 +568,7 @@ export async function siteCommandDetected(commandRun) {
                   // these have fixed possible values
                   else if (['parent', 'theme'].includes(nodeProp)) {
                     let l = nodeProp === 'parent' ? "-- no parent --" : "-- no theme --";
-                    let list = nodeProp === 'parent' ? await siteItemsOptionsList(activeHaxsite,  page.id) : await siteThemeList();
+                    let list = nodeProp === 'parent' ? await siteItemsOptionsList(activeHaxsite,  page.id) : await siteThemeList(true);
                     propValue = await p.select({
                       message: `${nodeProp}:`,
                       defaultValue: val,
@@ -721,7 +721,7 @@ export async function siteCommandDetected(commandRun) {
         case "site:theme":
           try {
             //theme
-            let list = await siteThemeList();
+            let list = await siteThemeList(true);
             activeHaxsite = await hax.systemStructureContext();
             let val = activeHaxsite.manifest.metadata.theme.element;
             if (!commandRun.options.theme) {
@@ -1240,15 +1240,29 @@ export async function siteItemsOptionsList(activeHaxsite, skipId = null) {
   return optionItems;
 }
 
-export async function siteThemeList() {
-  let themes = await HAXCMS.getThemes();
+export async function siteThemeList(coreOnly = true) {
   let items = [];
-  for (var i in themes) {
-    items.push({
-      value: i,
-      label: themes[i].name
-    })
+  if(coreOnly){
+    items = [
+      { value: 'clean-one', label: 'Clean One' },
+      { value: 'clean-two', label: 'Clean Two' },
+      { value: 'clean-portfolio-theme', label: 'Clean Portfolio' },
+      { value: 'haxor-slevin', label: 'Haxor Blog' },
+      { value: 'polaris-flex-theme', label: 'Polaris - Flex' },
+      { value: 'polaris-flex-sidebar', label: 'Polaris - Flex Sidebar' },
+      { value: 'polaris-invent-theme', label: 'Polaris - Invent' },
+      { value: 'custom-theme', label: 'Create Custom Theme' }
+    ];
+  } else {
+    let themes = await HAXCMS.getThemes();
+    for (var i in themes) {
+      items.push({
+        value: i,
+        label: themes[i].name
+      })
+    }
   }
+  
   return items;
 }
 
@@ -1312,7 +1326,7 @@ async function customSiteTheme(commandRun, project) {
   // add theme to site.json
   let themeObj = {
       element: project.customThemeName,
-      path: filePath,
+      path: "./custom/build/custom.es6.js",
       name: project.className,
   }
 


### PR DESCRIPTION
## New Features
* The `site:theme` action now supports the creation of custom themes, both through the command line and Clack TUI. 
* Consolidated the new core themes list as a default output from our `siteThemeList()` function.
* Fixed an input error for the `Winston.js` logger. New sites would have a `hax start undefined` recipe when using Clack.

## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2236
* https://github.com/haxtheweb/issues/issues/2196