### PR TITLE
[wc:actions] DX rework to managing webcomponent repos in HAXcli

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -46,6 +46,7 @@ async function main() {
   .option('--debug', 'Output for developers')
   .option('--format <char>', 'Output format; json (default), yaml')
   .option('--path <char>', 'where to perform operation')
+  .option('--name <char>', 'name of the project/web component')
   .option('--npm-client <char>', 'npm client to use (must be installed) npm, yarn, pnpm', 'npm')
   .option('--y', 'yes to all questions')
   .option('--skip', 'skip frills like animations')
@@ -66,7 +67,6 @@ async function main() {
   .option('--import-structure <char>', `import method to use:\n\rpressbooksToSite\n\relmslnToSite\n\rhaxcmsToSite\n\rnotionToSite\n\rgitbookToSite\n\revolutionToSite\n\rhtmlToSite\n\rdocxToSite`)
   .option('--node-op <char>', 'node operation to perform')
   .option('--item-id <char>', 'node ID to operate on')
-  .option('--name <char>', 'name of the project')
   .option('--domain <char>', 'published domain name')
   .option('--title-scrape <char>', 'CSS Selector for `title` in resource')
   .option('--content-scrape <char>', 'CSS Selector for `body` in resource')
@@ -142,24 +142,25 @@ async function main() {
   }
   // webcomponent program
   program
-  .command('webcomponent')
+  .command('wc')
   .description('Create Lit based web components, with HAX recommendations')
-  .argument('[name]', 'name of the project')
-  .action((name) => {
+  .argument('[action]', 'Actions to perform on web component include:')
+  .action((action) => {
     commandRun = {
       command: 'webcomponent',
       arguments: {},
       options: {}
     };
     // if name set, populate
-    if (name) {
-      commandRun.arguments.name = name;
+    if (action) {
+      commandRun.arguments.action = action;
       commandRun.options.skip = true;
     }
   })
   .option('--path <char>', 'path the project should be created in')
   .option('--org <char>', 'organization for package.json')
   .option('--author <char>', 'author for site / package.json')
+  .option('--name <char>', 'name of the web component')
   .option('--writeHaxProperties', 'Write haxProperties for the element')
   .option('--to-file <char>', 'redirect command output to a file')
   .option('--no-extras', 'skip all extra / automatic command processing')
@@ -404,7 +405,7 @@ async function main() {
               }
             },
             name: ({ results }) => {
-              if (!commandRun.arguments.action && !commandRun.arguments.name) {
+              if (!commandRun.arguments.action) {
                 let placeholder = "mysite";
                 let message = "Site name:";
                 if (commandRun.command === "webcomponent" || results.type === "webcomponent") {
@@ -449,8 +450,8 @@ async function main() {
                   }
                 });  
               }
-              if (commandRun.arguments.name) {
-                let value = commandRun.arguments.name;
+              if (commandRun.arguments.action) {
+                let value = commandRun.arguments.action;
                 if (!value) {
                   program.error(color.red("Name is required (tab writes default)"));
                   process.exit(1);
@@ -639,7 +640,7 @@ async function main() {
         );
         // merge cli options with project options assume this is NOT a monorepo
         // but spread will overwrite if needed
-        if (commandRun.command === 'webcomponent' && !commandRun.arguments.name) {
+        if (commandRun.command === 'webcomponent' && !commandRun.arguments.action) {
           project = {
             isMonorepo: false,
             ...project,
@@ -656,12 +657,13 @@ async function main() {
         }
         project.year = new Date().getFullYear();
         project.version = await HAXCMS.getHAXCMSVersion();
+        if (!project.name && commandRun.arguments.action) {
+          project.name = commandRun.arguments.action;
+        }
+
         // resolve site vs multi-site
         switch (project.type) {
           case 'site':
-            if (!project.name && commandRun.arguments.action) {
-              project.name = commandRun.arguments.action;
-            }
             // only set path if not already set
             if (!commandRun.options.path) {
               commandRun.options.path = process.cwd();

--- a/src/create.js
+++ b/src/create.js
@@ -10,7 +10,7 @@ import color from 'picocolors';
 import { haxIntro, communityStatement } from "./lib/statements.js";
 import { log, consoleTransport, logger } from "./lib/logging.js";
 import { auditCommandDetected } from './lib/programs/audit.js';
-import { webcomponentProcess, webcomponentCommandDetected } from "./lib/programs/webcomponent.js";
+import { webcomponentProcess, webcomponentCommandDetected, webcomponentActions } from "./lib/programs/webcomponent.js";
 import { siteActions, siteNodeOperations, siteProcess, siteCommandDetected, siteThemeList } from "./lib/programs/site.js";
 import { camelToDash } from "./lib/utils.js";
 import * as hax from "@haxtheweb/haxcms-nodejs";
@@ -140,11 +140,17 @@ async function main() {
     program.option(`--${camelToDash(siteNodeOps[i].value)} <char>`, `${siteNodeOps[i].label}`)
     siteProg.option(`--${camelToDash(siteNodeOps[i].value)} <char>`, `${siteNodeOps[i].label}`)
   }
+
   // webcomponent program
+  let strWebcomponentActions = '';
+  webcomponentActions().forEach(action => {
+    strWebcomponentActions += `${action.value} - ${action.label}` + "\n\r";
+  });
   program
   .command('wc')
+  .alias('webcomponent')
   .description('Create Lit based web components, with HAX recommendations')
-  .argument('[action]', 'Actions to perform on web component include:')
+  .argument('[action]', 'Actions to perform on web component include:' + "\n\r" + strWebcomponentActions)
   .action((action) => {
     commandRun = {
       command: 'webcomponent',

--- a/src/lib/programs/webcomponent.js
+++ b/src/lib/programs/webcomponent.js
@@ -510,7 +510,7 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
           }
           
           const filePath = `${project.path}/${project.name}.js`
-          await fs.copyFileSync(`${process.mainModule.path}/templates/webcomponent/generic/webcomponent.js`, filePath)
+          await fs.copyFileSync(`${process.mainModule.path}/templates/generic/webcomponent.js`, filePath)
 
           try {
             const ejsString = ejs.fileLoader(filePath, 'utf8');

--- a/src/lib/programs/webcomponent.js
+++ b/src/lib/programs/webcomponent.js
@@ -297,6 +297,15 @@ ${color.underline(color.cyan(`http://localhost:${port}`))}
   }
 }
 
+export function webcomponentActions(){
+  return [
+    { value: 'start', label: "Launch project"},
+    { value: 'wc:stats', label: "Check status of web component"},
+    { value: 'wc:element', label: "Add a new Lit module to an existing project"},
+    { value: 'wc:haxproperties', label: "Write haxProperties schema"},
+  ];
+}
+
 // autodetect webcomponent
 export async function webcomponentCommandDetected(commandRun, packageData = {}, port = "8000") {
   if (!commandRun.options.quiet) {
@@ -304,12 +313,7 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
     p.intro(`${color.bgBlue(color.white(` Web component name: ${packageData.name} `))}`);  
   }
 
-  let actions = [
-    { value: 'start', label: "Launch project"},
-    { value: 'wc:stats', label: "Check status of web component"},
-    { value: 'wc:element', label: "Add a new Lit module to an existing project"},
-    { value: 'wc:haxproperties', label: "Write haxProperties schema"},
-  ]
+  let actions = webcomponentActions();
 
   let actionAssigned = false;
   // default to status unless already set so we don't issue a create in a create
@@ -398,6 +402,8 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
       break;
       case "wc:status":
       case "wc:stats":
+      case "webcomponent:status":
+      case "webcomponent:stats":
         let webcomponentStats = {};
         if(packageData){
           webcomponentStats.title = packageData.name;
@@ -434,6 +440,7 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
         }
       break;
       case "wc:element":
+      case "webcomponent:element":
         if(packageData){
           if(!commandRun.options.name){
             commandRun.options.name = await p.text({
@@ -535,6 +542,7 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
 
       break;
       case "wc:haxproperties":
+      case "webcomponent:haxproperties":
         if (packageData.customElements) {
           await webcomponentGenerateHAXSchema(commandRun, packageData);
         } else {

--- a/src/templates/generic/webcomponent.js
+++ b/src/templates/generic/webcomponent.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright <%= year %> <%= author %>
+ * @license Apache-2.0, see LICENSE for full text.
+ */
+import { LitElement, html, css } from "lit";
+import { DDDSuper } from "@haxtheweb/d-d-d/d-d-d.js";
+import { I18NMixin } from "@haxtheweb/i18n-manager/lib/I18NMixin.js";
+
+/**
+ * `<%= name %>`
+ * 
+ * @demo index.html
+ * @element <%= name %>
+ */
+export class <%= className %> extends DDDSuper(I18NMixin(LitElement)) {
+
+  static get tag() {
+    return "<%= name %>";
+  }
+
+  constructor() {
+    super();
+    this.title = "";
+    this.t = this.t || {};
+    this.t = {
+      ...this.t,
+      title: "Title",
+    };
+    this.registerLocalization({
+      context: this,
+      localesPath:
+        new URL("./locales/<%= mainModule %>.ar.json", import.meta.url).href +
+        "/../",
+      locales: ["ar", "es", "hi", "zh"],
+    });
+  }
+
+  // Lit reactive properties
+  static get properties() {
+    return {
+      ...super.properties,
+      title: { type: String },
+    };
+  }
+
+  // Lit scoped styles
+  static get styles() {
+    return [super.styles,
+    css`
+      :host {
+        display: block;
+        color: var(--ddd-theme-primary);
+        background-color: var(--ddd-theme-accent);
+        font-family: var(--ddd-font-navigation);
+      }
+      .wrapper {
+        margin: var(--ddd-spacing-2);
+        padding: var(--ddd-spacing-4);
+      }
+      h3 span {
+        font-size: var(--<%= name %>-label-font-size, var(--ddd-font-size-s));
+      }
+    `];
+  }
+
+  // Lit render the HTML
+  render() {
+    return html`
+<div class="wrapper">
+  <h3><span>${this.t.title}:</span> ${this.title}</h3>
+  <slot></slot>
+</div>`;
+  }
+
+  /**
+   * haxProperties integration via file reference
+   */
+  static get haxProperties() {
+    return new URL(`./lib/${this.tag}.haxProperties.json`, import.meta.url)
+      .href;
+  }
+}
+
+globalThis.customElements.define(<%= className %>.tag, <%= className %>);


### PR DESCRIPTION
## New Features
* Reworked `webcomponentCommandDetected` to follow the `site:actions` design pattern 
* Abbreviated `hax webcomponent` argument to `hax wc`. There's still an optional alias to the full `webcomponent` keyword.
* Migrated `hax wc [name]` to `hax wc [action]` 
* Implemented Clack prompt menu for current `wc:actions`
* Added `wc:element` action that allows users to add a single new component to the current project repo

## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2258
* https://github.com/haxtheweb/issues/issues/2260