### PR TITLE
[site:actions] Implement site:element and serve actions for HAXcli

### DIFF
--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -92,6 +92,7 @@ class Res {
 export function siteActions() {
   return [
     { value: 'start', label: "Launch site in browser (http://localhost)"},
+    { value: 'serve', label: "Launch site in development mode"},
     { value: 'node:stats', label: "Node Stats / data"},
     { value: 'node:add', label: "Add a new page"},
     { value: 'node:edit', label: "Edit a page"},
@@ -362,9 +363,23 @@ export async function siteCommandDetected(commandRun) {
           try {
             if (!commandRun.options.quiet) {
               p.intro(`Starting server.. `);
-              p.intro(`⌨️  To stop server, press: ${color.bold(color.black(color.bgRed(` CTRL + C or CTRL + BREAK `)))}`);  
-            }
+              p.note(`🚀 Server running at: ${color.underline(color.cyan(`http://localhost:3000`))}
+⌨️  To stop server, press: ${color.bold(color.black(color.bgRed(` CTRL + C or CTRL + BREAK `)))}`);            }
             await exec(`cd ${activeHaxsite.directory} && npx @haxtheweb/haxcms-nodejs`);
+          }
+          catch(e) {
+            log(e.stderr);
+          }
+        break;
+        case "serve":
+          try {
+            if (!commandRun.options.quiet) {
+              p.intro(`Starting server.. `);
+              p.note(`🚀 Server running at: ${color.underline(color.cyan(`http://localhost:3000`))}
+💻 Site will live reload on changes to ${color.bold('custom/src')}
+⌨️  To stop server, press: ${color.bold(color.black(color.bgRed(` CTRL + C or CTRL + BREAK `)))}`);
+            }
+            await exec(`cd ${activeHaxsite.directory} && NODE_ENV=development npx ~/Workspace/hax/haxcms-nodejs`);
           }
           catch(e) {
             log(e.stderr);

--- a/src/lib/programs/webcomponent.js
+++ b/src/lib/programs/webcomponent.js
@@ -540,7 +540,7 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
         } catch(e) {
           log(e.stderr)
           // Original ejs.render error checking
-          console.error(color.red(filePath));
+          console.error(color.red(process.cwd()));
           console.error(color.red(e));
         }
 

--- a/src/lib/programs/webcomponent.js
+++ b/src/lib/programs/webcomponent.js
@@ -301,7 +301,7 @@ export function webcomponentActions(){
   return [
     { value: 'start', label: "Launch project"},
     { value: 'wc:stats', label: "Check status of web component"},
-    { value: 'wc:element', label: "Add a new Lit module to an existing project"},
+    { value: 'wc:element', label: "Add new Lit component to existing project"},
     { value: 'wc:haxproperties', label: "Write haxProperties schema"},
   ];
 }

--- a/src/templates/generic/sitecomponent.js
+++ b/src/templates/generic/sitecomponent.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright <%= year %> <%= author %>
+ * @license Apache-2.0, see LICENSE for full text.
+ */
+import { LitElement, html, css } from "lit";
+import { DDDSuper } from "@haxtheweb/d-d-d/d-d-d.js";
+import { I18NMixin } from "@haxtheweb/i18n-manager/lib/I18NMixin.js";
+
+/**
+ * `<%= name %>`
+ * 
+ * @demo index.html
+ * @element <%= name %>
+ */
+export class <%= className %> extends DDDSuper(I18NMixin(LitElement)) {
+
+  static get tag() {
+    return "<%= name %>";
+  }
+
+  constructor() {
+    super();
+    this.title = "";
+    this.t = this.t || {};
+    this.t = {
+      ...this.t,
+      title: "Title",
+    };
+
+  }
+
+  // Lit reactive properties
+  static get properties() {
+    return {
+      ...super.properties,
+      title: { type: String },
+    };
+  }
+
+  // Lit scoped styles
+  static get styles() {
+    return [super.styles,
+    css`
+      :host {
+        display: block;
+        color: var(--ddd-theme-primary);
+        background-color: var(--ddd-theme-accent);
+        font-family: var(--ddd-font-navigation);
+      }
+      .wrapper {
+        margin: var(--ddd-spacing-2);
+        padding: var(--ddd-spacing-4);
+      }
+      h3 span {
+        font-size: var(--<%= name %>-label-font-size, var(--ddd-font-size-s));
+      }
+    `];
+  }
+
+  // Lit render the HTML
+  render() {
+    return html`
+<div class="wrapper">
+  <h3><span>${this.t.title}:</span> ${this.title}</h3>
+  <slot></slot>
+</div>`;
+  }
+
+  /**
+   * haxProperties integration via file reference
+   */
+  static get haxProperties() {
+    return new URL(`./lib/${this.tag}.haxProperties.json`, import.meta.url)
+      .href;
+  }
+}
+
+globalThis.customElements.define(<%= className %>.tag, <%= className %>);


### PR DESCRIPTION
## New Features:
* `hax site site:element` will generate a single new web component file in `/custom/src/`. It ports over `hax wc wc:element` to site contexts.
* `hax site serve` will launch HAXsites with the `NODE_ENV=development` environment variable. This activates the live reload feature from `haxcms-nodejs`.
* Added the browser url (`http://localhost:3000`) to `hax site start` and `hax site serve` dialogues. 

## Related Issue(s):
* https://github.com/haxtheweb/issues/issues/2289
* https://github.com/haxtheweb/issues/issues/2258