### PR TITLE
[HAXcli] Top-level hax serve command

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -313,29 +313,31 @@ async function main() {
   if (commandRun.options.debug) {
     log(packageData, 'debug');
   }
-  // If CLI is in a site context and we want to serve the dev environment
-  if (commandRun.command === 'serve'){
-    if(await hax.systemStructureContext()){
+  // CLI works within context of the site if one is detected, otherwise we can do other thingss
+  if (await hax.systemStructureContext()) {
+    if (commandRun.command === 'serve'){
       commandRun.program = 'serve';
       commandRun.options.skip = true;
       await siteCommandDetected(commandRun);
     } else {
-      console.error(color.red('Must be in HAXsite context to run serve command'));
+      commandRun.program = 'site';
+      commandRun.options.skip = true;
+      await siteCommandDetected(commandRun);
     }
-  }
-  // CLI works within context of the site if one is detected, otherwise we can do other thingss
-  else if (await hax.systemStructureContext()) {
-    commandRun.program = 'site';
-    commandRun.options.skip = true;
-    await siteCommandDetected(commandRun);
   }
   else if (commandRun.command === 'audit') {
     auditCommandDetected(commandRun)
   }
   else if (packageData && (packageData.customElements || packageData.hax && packageData.hax.cli) && packageData.scripts.start) {
-    commandRun.program = 'webcomponent';
-    commandRun.options.skip = true;
-    await webcomponentCommandDetected(commandRun, packageData);
+    if (commandRun.command === 'serve'){
+      commandRun.program = 'serve';
+      commandRun.options.skip = true;
+      await webcomponentCommandDetected(commandRun, packageData);
+    } else {
+      commandRun.program = 'webcomponent';
+      commandRun.options.skip = true;
+      await webcomponentCommandDetected(commandRun, packageData);
+    }
   }
   else {
     if (commandRun.command === 'start' && !commandRun.options.y && !commandRun.options.auto && !commandRun.options.skip && !commandRun.options.quiet) {

--- a/src/create.js
+++ b/src/create.js
@@ -91,6 +91,19 @@ async function main() {
     };
   });
 
+  program
+  .command('serve')
+  .description('Launch HAXsite in development mode (http://localhost)')
+  .action(() => {
+    commandRun = {
+      command: 'serve',
+      arguments: {
+        action: 'serve'
+      },
+      options: {}
+    };
+  });
+
   // site operations and actions
   let strActions = '';
   siteActions().forEach(action => {
@@ -300,8 +313,18 @@ async function main() {
   if (commandRun.options.debug) {
     log(packageData, 'debug');
   }
+  // If CLI is in a site context and we want to serve the dev environment
+  if (commandRun.command === 'serve'){
+    if(await hax.systemStructureContext()){
+      commandRun.program = 'serve';
+      commandRun.options.skip = true;
+      await siteCommandDetected(commandRun);
+    } else {
+      console.error(color.red('Must be in HAXsite context to run serve command'));
+    }
+  }
   // CLI works within context of the site if one is detected, otherwise we can do other thingss
-  if (await hax.systemStructureContext()) {
+  else if (await hax.systemStructureContext()) {
     commandRun.program = 'site';
     commandRun.options.skip = true;
     await siteCommandDetected(commandRun);

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -374,7 +374,7 @@ export async function siteCommandDetected(commandRun) {
         case "serve":
           try {
             if (!commandRun.options.quiet) {
-              p.intro(`Starting server.. `);
+              p.intro(`Starting server in development mode.. `);
               p.note(`🚀 Server running at: ${color.underline(color.cyan(`http://localhost:3000`))}
 💻 Site will live reload on changes to ${color.bold('custom/src')}
 ⌨️  To stop server, press: ${color.bold(color.black(color.bgRed(` CTRL + C or CTRL + BREAK `)))}`);

--- a/src/lib/programs/webcomponent.js
+++ b/src/lib/programs/webcomponent.js
@@ -400,6 +400,56 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
           // don't log bc output is odd
         }
       break;
+      case "serve":
+        try {
+          if (!commandRun.options.quiet) {
+            console.log(commandRun.options.npmClient);
+            p.intro(`Launching development server.. `);
+          }
+          if (packageData.scripts.serve){
+            if (!commandRun.options.quiet) {
+            p.note(`${merlinSays(`Project launched in development mode`)}
+
+🚀  Running your ${color.bold('webcomponent')} ${color.bold(packageData.name)}:
+      ${color.underline(color.cyan(`http://localhost:${port}`))}
+
+🏠  Launched: ${color.underline(color.bold(color.yellow(color.bgBlack(`${process.cwd()}`))))}
+💻  Folder: ${color.bold(color.yellow(color.bgBlack(`cd ${process.cwd()}`)))}
+📂  Open folder: ${color.bold(color.yellow(color.bgBlack(`open ${process.cwd()}`)))}
+📘  VS Code Project: ${color.bold(color.yellow(color.bgBlack(`code ${process.cwd()}`)))}
+🚧  Launch later: ${color.bold(color.yellow(color.bgBlack(`${commandRun.options.npmClient} serve`)))}
+
+⌨️  To exit 🧙 Merlin press: ${color.bold(color.black(color.bgRed(` CTRL + C or CTRL + BREAK `)))}
+          `);
+            }
+
+            await exec(`${commandRun.options.npmClient} run serve`);
+          } else {
+            // if no serve script, run start instead
+            if (!commandRun.options.quiet) {
+            p.note(`${merlinSays(`No ${color.bold('serve')} script found, running ${color.bold(`${commandRun.options.npmClient} start`)} instead`)}
+
+🚀  Running your ${color.bold('webcomponent')} ${color.bold(packageData.name)}:
+      ${color.underline(color.cyan(`http://localhost:${port}`))}
+
+🏠  Launched: ${color.underline(color.bold(color.yellow(color.bgBlack(`${process.cwd()}`))))}
+💻  Folder: ${color.bold(color.yellow(color.bgBlack(`cd ${process.cwd()}`)))}
+📂  Open folder: ${color.bold(color.yellow(color.bgBlack(`open ${process.cwd()}`)))}
+📘  VS Code Project: ${color.bold(color.yellow(color.bgBlack(`code ${process.cwd()}`)))}
+🚧  Launch later: ${color.bold(color.yellow(color.bgBlack(`${commandRun.options.npmClient} start`)))}
+
+⌨️  To exit 🧙 Merlin press: ${color.bold(color.black(color.bgRed(` CTRL + C or CTRL + BREAK `)))}
+          `);
+            }
+
+            await exec(`${commandRun.options.npmClient} start`);
+          }
+        }
+        catch(e) {
+          // don't log bc output is odd
+          console.log("error", e);
+        }
+      break;
       case "wc:status":
       case "wc:stats":
       case "webcomponent:status":


### PR DESCRIPTION
## New Features
* Users can directly call `hax serve` in the CLI. This acts as a new shortcut/alias to either `hax site serve` or `hax wc serve`.
* `hax wc serve` will call `npm run serve` if it's in the `package.json`. If not, it will fallback to running `npm start` with a warning message.
* The built-in detection for site vs web component context is used here too. It validates which command to route to.

## Related Issue
* https://github.com/haxtheweb/issues/issues/2289