### PR TITLE
[hax party] Community onboarding workflow! Party time!

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,15 +51,16 @@
     "ejs": "3.1.10",
     "js-yaml": "4.1.0",
     "node-html-parser": "6.1.13",
+    "open": "^10.1.2",
     "picocolors": "1.0.1",
     "winston": "3.17.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.27.0",
     "@babel/core": "^7.26.10",
+    "@babel/plugin-syntax-import-attributes": "^7.26.0",
     "@babel/preset-env": "^7.26.9",
     "@babel/register": "^7.25.9",
-    "@babel/plugin-syntax-import-attributes": "^7.26.0",
     "@custom-elements-manifest/analyzer": "^0.10.3",
     "babel-plugin-transform-dynamic-import": "^2.1.0",
     "commit-and-tag-version": "12.4.1",

--- a/src/create.js
+++ b/src/create.js
@@ -4,7 +4,6 @@ process.env.haxcms_middleware = "node-cli";
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as os from "node:os";
 import * as p from '@clack/prompts';
 import color from 'picocolors';
 

--- a/src/create.js
+++ b/src/create.js
@@ -243,6 +243,7 @@ async function main() {
       commandRun.options.skip = true;
     }
   })
+  .option('--root <char>', 'root location to execute the command from')
   .option('--repos <char...>', 'repositories to clone')
   .version(packageJson.version);
 

--- a/src/create.js
+++ b/src/create.js
@@ -514,6 +514,8 @@ async function main() {
               }
             },
             name: ({ results }) => {
+              const reservedNames = ["annotation-xml", "color-profile", "font-face", "font-face-src", "font-face-uri", "font-face-format", "font-face-name", "missing-glyph"];
+
               if (!commandRun.arguments.action) {
                 let placeholder = "mysite";
                 let message = "Site name:";
@@ -529,11 +531,17 @@ async function main() {
                     if (!value) {
                       return "Name is required (tab writes default)";
                     }
+                    if(reservedNames.includes(value)) {
+                      return `Reserved name ${color.bold(value)} cannot be used`
+                    }
                     if (value.toLocaleLowerCase() !== value) {
                       return "Name must be lowercase";
                     }
                     if (/^\d/.test(value)) {
                       return "Name cannot start with a number";
+                    }
+                    if (/[`~!@#$%^&*()_=+\[\]{}|;:\'",<.>\/?\\]/.test(value)) {
+                      return "No special characters allowed in name";
                     }
                     if (value.indexOf(' ') !== -1) {
                       return "No spaces allowed in name";
@@ -544,6 +552,10 @@ async function main() {
                     // test that this is not an existing element we use in the registry
                     if (results.type === "webcomponent" && wcReg[value]) {
                       return "Name is already a web component in the wc-registry published for HAX.";
+                    }
+                    // Check for any other syntax errors
+                    if(results.type === "webcomponent" && !/^[a-z][a-z0-9.\-]*\-[a-z0-9.\-]*$/.test(value)){
+                      return `Name must follow the syntax ${color.bold("my-component")}`;
                     }
                     // assumes auto was selected in CLI
                     let joint = process.cwd();
@@ -565,12 +577,17 @@ async function main() {
                   program.error(color.red("Name is required (tab writes default)"));
                   process.exit(1);
                 }
+                if(reservedNames.includes(value)) {
+                  program.error(color.red(`Reserved name ${color.bold(value)} cannot be used`));
+                  process.exit(1);
+                }
                 if (value.toLocaleLowerCase() !== value) {
                   program.error(color.red("Name must be lowercase"));
                   process.exit(1);
                 }
                 if (/^\d/.test(value)) {
                   program.error(color.red("Name cannot start with a number"));
+                  process.exit(1);
                 }
                 if (value.indexOf(' ') !== -1) {
                   program.error(color.red("No spaces allowed in name"));
@@ -583,6 +600,11 @@ async function main() {
                 // test that this is not an existing element we use in the registry
                 if (results.type === "webcomponent" && wcReg[value]) {
                   program.error(color.red("Name is already a web component in the wc-registry published for HAX."));
+                  process.exit(1);
+                }
+                // Check for any other syntax errors
+                if(results.type === "webcomponent" && !/^[a-z][a-z0-9.\-]*\-[a-z0-9.\-]*$/.test(value)){
+                  program.error(color.red(`Name must follow the syntax ${color.bold("my-component")}`));
                   process.exit(1);
                 }
                 // assumes auto was selected in CLI

--- a/src/create.js
+++ b/src/create.js
@@ -11,6 +11,7 @@ import color from 'picocolors';
 import { haxIntro, communityStatement } from "./lib/statements.js";
 import { log, consoleTransport, logger } from "./lib/logging.js";
 import { auditCommandDetected } from './lib/programs/audit.js';
+import { partyCommandDetected } from './lib/programs/party.js';
 import { webcomponentProcess, webcomponentCommandDetected, webcomponentActions } from "./lib/programs/webcomponent.js";
 import { siteActions, siteNodeOperations, siteProcess, siteCommandDetected, siteThemeList } from "./lib/programs/site.js";
 import { camelToDash, exec, interactiveExec, writeConfigFile, readConfigFile, getTimeDifference } from "./lib/utils.js";
@@ -85,6 +86,10 @@ async function main() {
   .option('--recipe <char>', 'path to recipe file')
   .option('--custom-theme-name <char>', 'custom theme name')
   .option('--custom-theme-template <char>', 'custom theme template; (options: base, polaris-flex, polaris-sidebar)')
+
+  // options for party
+  .option('--repos <char...>', 'repositories to clone') 
+
   .version(packageJson.version)
   .helpCommand(true);
 
@@ -224,6 +229,24 @@ async function main() {
   .option('--debug', 'Output for developers')
   .version(packageJson.version);
 
+  program
+  .command('party')
+  .description('Party time! Join the HAX community and get involved!')
+  .argument('[action]', 'Actions to perform on web component include:' + "\n\r" + "test")
+  .action((action) => {
+    commandRun = {
+      command: 'party',
+      arguments: {},
+      options: {}
+    };
+    if (action) {
+      commandRun.arguments.action = action;
+      commandRun.options.skip = true;
+    }
+  })
+  .option('--repos <char...>', 'repositories to clone')
+  .version(packageJson.version);
+
   // process program arguments
   program.parse();
   commandRun.options = {...commandRun.options, ...program.opts()};
@@ -346,6 +369,9 @@ async function main() {
     }
     auditCommandDetected(commandRun, customPath)
   }
+  else if (commandRun.command === 'party') {
+    await partyCommandDetected(commandRun);
+  }
   // CLI works within context of the site if one is detected, otherwise we can do other things
   else if (await hax.systemStructureContext()) {
     if (commandRun.command === 'serve'){
@@ -415,6 +441,7 @@ async function main() {
         let buildOptions = [
           { value: 'webcomponent', label: '🏗️ Create a Web Component' },
           { value: 'site', label: '🏡 Create a HAXsite'},
+          { value: 'party', label: '🎉 Join the HAX community' },
           { value: 'update', label: '🤓 Check for hax cli updates' },
           { value: 'quit', label: '🚪 Quit' },
         ];
@@ -444,6 +471,8 @@ async function main() {
       }
       if (project.type === "update") {
         await testForUpdates(commandRun);
+      } else if (project.type === "party") {
+        await partyCommandDetected(commandRun);
       }
       // detect being in a haxcms scaffold. easiest way is _sites being in this directory
       // set the path automatically so we skip the question

--- a/src/create.js
+++ b/src/create.js
@@ -244,6 +244,8 @@ async function main() {
     }
   })
   .option('--root <char>', 'root location to execute the command from')
+  .option('--y', 'yes to all questions')
+  .option('--auto', 'yes to all questions, alias of y')
   .option('--repos <char...>', 'repositories to clone')
   .version(packageJson.version);
 

--- a/src/lib/programs/party.js
+++ b/src/lib/programs/party.js
@@ -138,6 +138,7 @@ export async function partyCommandDetected(commandRun) {
       case "gh":
       case "github":
         try {
+          // auto and y are aliases
           if(!commandRun.options.root && !commandRun.options.auto){
             commandRun.options.root = await p.text({
               message: 'What folder will your HAX projects live in?',
@@ -171,13 +172,17 @@ export async function partyCommandDetected(commandRun) {
 
           p.note(`${merlinSays(`${color.magenta(color.bold('HAX is a party,'))} so you can select ${color.bold('multiple')} repositories at once!`)}
       Remember to ${color.bold('fork each project')} on ${color.bold('GitHub')} (or you'll be asked to later!)`);
-          if(!commandRun.options.repos) {
+          if(!commandRun.options.repos && commandRun.options.auto){
+            commandRun.options.repos = initialValues;
+          } else if(!commandRun.options.repos) {
             commandRun.options.repos = await p.multiselect({
               message: 'Choose GitHub repositories to clone',
               initialValues: initialValues,
               options: options,
               required: false,
             })
+          } else if (commandRun.options.repos.includes("all")) {
+            commandRun.options.repos = options.map((item) => item.value);
           }
           await cloneHAXRepositories(commandRun);
         } catch (e) { }

--- a/src/lib/programs/party.js
+++ b/src/lib/programs/party.js
@@ -27,10 +27,10 @@ export function partyActions(){
       { value: 'docs', label: "View the HAX documentation"},
       { value: 'playground', label: "Explore HAX.cloud playground"},
       { value: 'psu', label: "Visit official hax.psu.edu site"},
-      { value: 'issues', label: "View HAX issues on GitHub"},
+      { value: 'issues', label: "Engage with HAX issues on GitHub"},
       { value: 'discord', label: "Join the HAX Discord community"},
       { value: 'club', label: "Check out HAX The Club at PSU"},
-      { value: 'github', label: "Become a core developer for HAX"},
+      { value: 'github', label: "Contribute to core development for HAX"},
     ];
   }
 

--- a/src/lib/programs/party.js
+++ b/src/lib/programs/party.js
@@ -1,0 +1,223 @@
+import * as p from '@clack/prompts';
+import color from 'picocolors';
+import { exec } from "../utils.js";
+import open from 'open';
+
+export function partyActions(){
+    return [
+      { value: 'docs', label: "View the HAX documentation"},
+      { value: 'playground', label: "Explore HAX.cloud playground"},
+      { value: 'psu', label: "Visit official hax.psu.edu site"},
+      { value: 'issues', label: "View HAX issues on GitHub"},
+      { value: 'discord', label: "Join the HAX Discord community"},
+      { value: 'club', label: "Check out HAX The Club at PSU"},
+      { value: 'github', label: "Become a core developer for HAX"},
+    ];
+  }
+
+//   async function runConfetti(duration = 500, options = {}) {
+//     const cliConfetti = require("cli-confetti");
+//     const CliUpdate = require("cli-update");
+
+//     let stopped = false;
+
+//     cliConfetti(options, function (err, confettiFrame) {
+//         if (err) throw err;
+//         if (stopped) return true;
+//         CliUpdate.render(confettiFrame);
+//     });
+
+//     setTimeout(() => {
+//         console.clear();
+//         stopped = true;
+//     //     // CliUpdate.done(); // optional
+//     //     // process.exit(0);  // optional
+//     }, duration);
+// }
+
+export async function partyCommandDetected(commandRun) {
+  if (!commandRun.options.quiet) {
+    p.intro(`${color.bgBlack(color.white(` HAXTheWeb : Party detected `))}`);
+  }
+
+  let actions = partyActions();
+
+  let actionAssigned = false;
+  // default to status unless already set so we don't issue a create in a create
+  if (!commandRun.arguments.action) {
+    actionAssigned = true;
+    commandRun.arguments.action = 'party:status';
+  }
+
+  commandRun.command = "party";
+
+  let operation = {
+    ...commandRun.arguments,
+    ...commandRun.options
+  };
+
+  actions.push({ value: 'quit', label: "🚪 Quit"});
+
+  while (operation.action !== 'quit') {
+    if (!operation.action) {
+      commandRun = {
+        command: null,
+        arguments: {},
+        options: { 
+          // npmClient: `${operation.npmClient}`
+        }
+      }
+      operation = await p.group(
+        {
+          action: ({ results }) =>
+            p.select({
+              message: `Actions you can take:`,
+              defaultValue: actions[0],
+              initialValue: actions[0],
+              options: actions,
+            }),
+        },
+        {
+          onCancel: () => {
+            if (!commandRun.options.quiet) {
+              p.cancel('🧙 Merlin: Canceling CLI.. HAX ya later 🪄');
+            }
+            process.exit(0);
+          },
+        });
+    }
+    if (operation.action) {
+      p.intro(`hax party ${color.bold(operation.action)}`);
+    }
+    switch (operation.action) {
+      case "party:status":
+      case "party:stats":
+        p.intro(`${color.bgBlue(color.white(` Party time `))}`);
+
+      break;
+      case "docs":
+        // open the docs
+        p.intro(`${color.bgBlue(color.white(` Opening in browser `))}`);
+        await open("https://haxtheweb.org/");
+      break;
+      case "playground":
+        // open the playground
+        p.intro(`${color.bgBlue(color.white(` Opening in browser `))}`);
+        await open("https://hax.cloud/");
+      break;
+      case "psu":
+        // open the psu site
+        p.intro(`${color.bgBlue(color.white(` Opening in browser `))}`);
+        await open("https://hax.psu.edu/");
+      break;
+      case "issues":
+        // open the issues
+        p.intro(`${color.bgBlue(color.white(` Opening in browser `))}`);
+        await open("https://github.com/haxtheweb/issues/issues");
+      break;
+      case "discord":
+        // open the discord
+        p.intro(`${color.bgBlue(color.white(` Opening in browser `))}`);
+        await open("https://discord.gg/haxtheweb");
+      break;
+      case "club":
+        // open the club
+        p.intro(`${color.bgBlue(color.white(` Opening in browser `))}`);
+        await open("https://orgcentral.psu.edu/organization/hax-the-club");
+        // we can change this to the club website when it's up
+      break;
+      case "gh":
+      case "github":
+        try {
+          // open the repos
+          const initialValues = [ "webcomponents" ];
+          const options = [ 
+            { value: "webcomponents", label: "Webcomponents Monorepo" }, 
+            { value: "create", label: "Create-CLI" }, 
+            { value: "hax-the-club", label: "HAX The Club" },
+            { value: "open-apis", label: "Open APIs" }, 
+            { value: "haxcms-nodejs", label: "HAXcms Node.js" }, 
+            { value: "haxcms-php", label: "HAXcms PHP"}, 
+            { value: "desktop", label: "HAXcms Desktop" }, 
+            { value: "haxiam", label: "HAXiam" }
+          ];
+          if(!commandRun.options.repos) {
+            commandRun.options.repos = await p.multiselect({
+              message: 'Choose GitHub repositories to clone',
+              initialValues: initialValues,
+              options: options,
+              required: false,
+            })
+          }
+          await createDevEnvironment(commandRun);
+        } catch (e) {
+          console.log(e);
+        }
+      break;
+      case "quit":
+        // quit
+        process.exit(0);
+      break;
+    }
+      // y or noi need to act like it ran and finish instead of looping options
+    if (commandRun.options.y || !commandRun.options.i || !actionAssigned) {
+      process.exit(0);
+    }
+    operation.action = null;
+  }
+}
+
+async function createDevEnvironment(commandRun) {
+  let sysGit = true;
+  exec('which git', error => {
+    if (error) {
+      sysGit = false;
+    }
+  });
+  
+  let author = '';
+  // should be able to grab if not predefined
+  try {
+    let value = await exec(`git config user.name`);
+    author = value.stdout.trim();
+  }
+  catch(e) {
+    log(`
+      git user name not configured. Run the following to do this:\n
+      git config --global user.name "namehere"\n
+      git config --global user.email "email@here`, 'debug');
+  }
+
+  console.log(commandRun.options.repos);
+  for (const item of commandRun.options.repos) {
+    console.log(`Cloning ${item} to ${process.cwd()}`);
+    try {
+      await exec(`git clone git@github.com:${author}/${item}.git`);
+    } catch (e) {
+      p.note(`Error: Fork the repository on GitHub: https://github.com/haxtheweb/${item}/fork`)
+    }
+
+    let s = p.spinner();
+    s.start(`Installing dependencies for ${item}`);
+    switch (item) {
+      case "webcomponents":
+        await exec(`yarn global add lerna web-component-analyzer`);
+        await exec(`cd ${process.cwd()}/${item} && yarn install`);
+      break;
+      case "create":
+      case "hax-the-club":
+      case "open-apis":
+      case "haxcms-nodejs":
+      case "desktop":
+        await exec(`cd ${process.cwd()}/${item} && npm install`)
+      break;
+      case "haxcms-php":
+        // ddev setup
+      break;
+      case "HAXiam":
+        // curl setup?
+      break;
+    }
+    s.stop(`Dependencies installed for ${item}`);
+  };
+}

--- a/src/lib/programs/party.js
+++ b/src/lib/programs/party.js
@@ -167,7 +167,7 @@ export async function partyCommandDetected(commandRun) {
             { value: "haxcms-nodejs", label: "HAXcms Node.js - haxtheweb/haxcms-nodejs" }, 
             { value: "haxcms-php", label: "HAXcms PHP - haxtheweb/haxcms-php" }, 
             { value: "desktop", label: "HAX The Desktop - haxtheweb/desktop" }, 
-            { value: "haxiam", label: "HAXiam - haxtheweb/HAXiam" }
+            { value: "HAXiam", label: "HAXiam - haxtheweb/HAXiam" }
           ];
 
           p.note(`${merlinSays(`${color.magenta(color.bold('HAX is a party,'))} so you can select ${color.bold('multiple')} repositories at once!`)}

--- a/src/lib/programs/party.js
+++ b/src/lib/programs/party.js
@@ -1,7 +1,9 @@
-import * as p from '@clack/prompts';
-import color from 'picocolors';
+import * as fs from 'node:fs';
 import { exec } from "../utils.js";
 import open from 'open';
+
+import * as p from '@clack/prompts';
+import color from 'picocolors';
 import { merlinSays } from "../statements.js";
 
 let sysGit = true;
@@ -89,7 +91,8 @@ export async function partyCommandDetected(commandRun) {
     switch (operation.action) {
       case "party:status":
       case "party:stats":
-      p.intro(`${color.green(color.bold(`         
+      if(!commandRun.options.quiet) {
+        p.intro(`${color.green(color.bold(`         
                        888            
                        888            
 88888b.  8888b. 888d888888888888  888 
@@ -99,6 +102,7 @@ export async function partyCommandDetected(commandRun) {
 88888P" "Y888888888     "Y888 "Y88888 
 888                               888 
 888                           Y8bd88P`))}`);
+      };
       break;
       case "docs":
         // open the docs
@@ -134,17 +138,35 @@ export async function partyCommandDetected(commandRun) {
       case "gh":
       case "github":
         try {
-          // open the repos
+          if(!commandRun.options.root && !commandRun.options.auto){
+            commandRun.options.root = await p.text({
+              message: 'What folder will your HAX projects live in?',
+              placeholder: process.cwd(),
+              required: true,
+              validate: (value) => {
+                if (!value) {
+                  return "Path is required (tab writes default)";
+                }
+                if (!fs.existsSync(value)) {
+                  return `${value} does not exist. Select a valid folder`;
+                }
+              }
+            })
+            // subprocesses are based on the root process folder
+            process.chdir(commandRun.options.root);
+          }
+
+          // list HAX repos
           const initialValues = [ "webcomponents" ];
           const options = [ 
-            { value: "webcomponents", label: "Webcomponents Monorepo" }, 
-            { value: "create", label: "Create CLI" }, 
-            { value: "hax-the-club", label: "HAX The Club" },
-            { value: "open-apis", label: "Open APIs" }, 
-            { value: "haxcms-nodejs", label: "HAXcms Node.js" }, 
-            { value: "haxcms-php", label: "HAXcms PHP"}, 
-            { value: "desktop", label: "HAXcms Desktop" }, 
-            { value: "haxiam", label: "HAXiam" }
+            { value: "webcomponents", label: "Webcomponents Monorepo - haxtheweb/webcomponents" }, 
+            { value: "create", label: "Create CLI - haxtheweb/create" }, 
+            { value: "hax-the-club", label: "HAX The Club - haxtheweb/hax-the-club" },
+            { value: "open-apis", label: "Open APIs - haxtheweb/open-apis" }, 
+            { value: "haxcms-nodejs", label: "HAXcms Node.js - haxtheweb/haxcms-nodejs" }, 
+            { value: "haxcms-php", label: "HAXcms PHP - haxtheweb/haxcms-php" }, 
+            { value: "desktop", label: "HAX The Desktop - haxtheweb/desktop" }, 
+            { value: "haxiam", label: "HAXiam - haxtheweb/HAXiam" }
           ];
 
           p.note(`${merlinSays(`${color.magenta(color.bold('HAX is a party,'))} so you can select ${color.bold('multiple')} repositories at once!`)}

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -823,7 +823,9 @@ export async function siteCommandDetected(commandRun) {
         break;
         case "site:element":
           try {
+            const reservedNames = ["annotation-xml", "color-profile", "font-face", "font-face-src", "font-face-uri", "font-face-format", "font-face-name", "missing-glyph"];
             activeHaxsite = await hax.systemStructureContext();
+
             if(!commandRun.options.name){
               commandRun.options.name = await p.text({
                 message: 'Component name:',
@@ -833,17 +835,27 @@ export async function siteCommandDetected(commandRun) {
                   if (!value) {
                     return "Name is required (tab writes default)";
                   }
+                  if(reservedNames.includes(value)) {
+                    return `Reserved name ${color.bold(value)} cannot be used`
+                  }
                   if (value.toLocaleLowerCase() !== value) {
                     return "Name must be lowercase";
                   }
                   if (/^\d/.test(value)) {
                     return "Name cannot start with a number";
                   }
+                  if (/[`~!@#$%^&*()_=+\[\]{}|;:\'",<.>\/?\\]/.test(value)) {
+                    return "No special characters allowed in name";
+                  }
                   if (value.indexOf(' ') !== -1) {
                     return "No spaces allowed in name";
                   }
                   if ((value.indexOf('-') === -1 || value.replace('--', '') !== value || value[0] === '-' || value[value.length-1] === '-')) {
                     return "Name must include at least one `-` and must not start or end name.";
+                  }
+                  // Check for any other syntax errors
+                  if(!/^[a-z][a-z0-9.\-]*\-[a-z0-9.\-]*$/.test(value)){
+                    return `Name must follow the syntax ${color.bold("my-component")}`;
                   }
                   // assumes auto was selected in CLI
                   let joint = process.cwd();
@@ -861,12 +873,21 @@ export async function siteCommandDetected(commandRun) {
                   console.error(color.red("Name is required (tab writes default)"));
                   process.exit(1);
                 }
+                if(reservedNames.includes(value)) {
+                  console.error(color.red(`Reserved name ${color.bold(value)} cannot be used`));
+                  process.exit(1);
+                }
                 if (value.toLocaleLowerCase() !== value) {
                   console.error(color.red("Name must be lowercase"));
                   process.exit(1);
                 }
                 if (/^\d/.test(value)) {
                   console.error(color.red("Name cannot start with a number"));
+                  process.exit(1);
+                }
+                if (/[`~!@#$%^&*()_=+\[\]{}|;:\'",<.>\/?\\]/.test(value)) {
+                  console.error(color.red("No special characters allowed in name"));
+                  process.exit(1);
                 }
                 if (value.indexOf(' ') !== -1) {
                   console.error(color.red("No spaces allowed in name"));
@@ -874,6 +895,11 @@ export async function siteCommandDetected(commandRun) {
                 }
                 if ((value.indexOf('-') === -1 || value.replace('--', '') !== value || value[0] === '-' || value[value.length-1] === '-')) {
                   console.error(color.red("Name must include at least one `-` and must not start or end name."));
+                  process.exit(1);
+                }
+                // Check for any other syntax errors
+                if(!/^[a-z][a-z0-9.\-]*\-[a-z0-9.\-]*$/.test(value)){
+                  console.error(color.red(`Name must follow the syntax ${color.bold("my-component")}`));
                   process.exit(1);
                 }
                 // assumes auto was selected in CLI

--- a/src/lib/programs/webcomponent.js
+++ b/src/lib/programs/webcomponent.js
@@ -399,7 +399,6 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
       case "serve":
         try {
           if (!commandRun.options.quiet) {
-            console.log(commandRun.options.npmClient);
             p.intro(`Launching development server.. `);
           }
           if (packageData.scripts.serve){

--- a/src/lib/programs/webcomponent.js
+++ b/src/lib/programs/webcomponent.js
@@ -491,6 +491,8 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
       case "wc:element":
       case "webcomponent:element":
         try {
+          const reservedNames = ["annotation-xml", "color-profile", "font-face", "font-face-src", "font-face-uri", "font-face-format", "font-face-name", "missing-glyph"];
+
           if(!commandRun.options.name){
             commandRun.options.name = await p.text({
               message: 'Component name:',
@@ -500,17 +502,27 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
                 if (!value) {
                   return "Name is required (tab writes default)";
                 }
+                if(reservedNames.includes(value)) {
+                  return `Reserved name ${color.bold(value)} cannot be used`
+                }
                 if (value.toLocaleLowerCase() !== value) {
                   return "Name must be lowercase";
                 }
                 if (/^\d/.test(value)) {
                   return "Name cannot start with a number";
                 }
+                if (/[`~!@#$%^&*()_=+\[\]{}|;:\'",<.>\/?\\]/.test(value)) {
+                  return "No special characters allowed in name";
+                }
                 if (value.indexOf(' ') !== -1) {
                   return "No spaces allowed in name";
                 }
                 if ((value.indexOf('-') === -1 || value.replace('--', '') !== value || value[0] === '-' || value[value.length-1] === '-')) {
                   return "Name must include at least one `-` and must not start or end name.";
+                }
+                // Check for any other syntax errors
+                if(!/^[a-z][a-z0-9.\-]*\-[a-z0-9.\-]*$/.test(value)){
+                  return `Name must follow the syntax ${color.bold("my-component")}`;
                 }
                 // assumes auto was selected in CLI
                 let joint = process.cwd();
@@ -528,12 +540,21 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
                 console.error(color.red("Name is required (tab writes default)"));
                 process.exit(1);
               }
+              if(reservedNames.includes(value)) {
+                console.error(color.red(`Reserved name ${color.bold(value)} cannot be used`));
+                process.exit(1);
+              }
               if (value.toLocaleLowerCase() !== value) {
                 console.error(color.red("Name must be lowercase"));
                 process.exit(1);
               }
               if (/^\d/.test(value)) {
                 console.error(color.red("Name cannot start with a number"));
+                process.exit(1);
+              }
+              if (/[`~!@#$%^&*()_=+\[\]{}|;:\'",<.>\/?\\]/.test(value)) {
+                console.error(color.red("No special characters allowed in name"));
+                process.exit(1);
               }
               if (value.indexOf(' ') !== -1) {
                 console.error(color.red("No spaces allowed in name"));
@@ -541,6 +562,11 @@ export async function webcomponentCommandDetected(commandRun, packageData = {}, 
               }
               if ((value.indexOf('-') === -1 || value.replace('--', '') !== value || value[0] === '-' || value[value.length-1] === '-')) {
                 console.error(color.red("Name must include at least one `-` and must not start or end name."));
+                process.exit(1);
+              }
+              // Check for any other syntax errors
+              if(!/^[a-z][a-z0-9.\-]*\-[a-z0-9.\-]*$/.test(value)){
+                console.error(color.red(`Name must follow the syntax ${color.bold("my-component")}`));
                 process.exit(1);
               }
               // assumes auto was selected in CLI


### PR DESCRIPTION
## New Features
![image](https://github.com/user-attachments/assets/018a7f7e-2d6a-46e5-b48a-46391f3b9621)

* New `hax party` command! :tada: It's designed to provide a smoother onboarding process for users, students, and new contributors. Welcome to the HAX community! :partying_face: 
* A major addition is shortcuts to several HAX resources like [hax.cloud](https://hax.cloud) and [hax.psu.edu](https://hax.psu.edu). 
    * We're using the `open` library to spawn web links into the user's default browser. This should be cross-platform and relatively robust. 
* `hax party gh` or `hax party github` can be used to automatically clone our core repositories from GitHub. It guides users to fork the right repositories.
    * The command can be scripted with `--y/--auto`. It will assume default values if neither argument is declared. 
    * `--repos` defaults to `webcomponents`. `--repos all` will select every repository.
* Input validation has been added to **site/webcomponent** naming. Users will receive new warnings when breaking syntax with special characters, reserved names, etc.

## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2259
* https://github.com/haxtheweb/issues/issues/2295
* https://github.com/haxtheweb/issues/issues/2261