### PR TITLE
[bugfix] Updated esbuild targets, resolves WC build error

### DIFF
--- a/src/templates/webcomponent/hax/rollup.config.js
+++ b/src/templates/webcomponent/hax/rollup.config.js
@@ -25,7 +25,7 @@ export default {
     /** Minify JS, compile JS to a lower language target */
     esbuild({
       minify: true,
-      target: ['chrome64', 'firefox67', 'safari11.1'],
+      target: ['chrome120', 'firefox121', 'edge120', 'safari17.2'],
     }),
     /** Bundle assets references via import.meta.url */
     importMetaAssets(),


### PR DESCRIPTION
## New Features
* Updated esbuild targets in our web component templates (maxing out at 3 years old)
* Resolves the build error we were seeing about Safari 11 and destructuring support
     ```
     [!] (plugin esbuild) Error: Transform failed with 13 errors:
    <stdin>:55:6: ERROR: Transforming destructuring to the configured target environment ("chrome64", "firefox67", "safari11.1") is not supported yet
     ``` 
* It seems that `esbuild` depends on a third-party compatibility table, which got updated recently
     * https://github.com/evanw/esbuild/issues/4436#issuecomment-4179795949 

## Related Issue(s)
* https://github.com/haxtheweb/issues/issues/2649