### PR TITLE
[create] v1 API conformance: site:search + site:export

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -108,7 +108,7 @@ async function main() {
   .option('--repos <char...>', 'repositories to clone') 
 
   // options for new site commands
-  .option('--export-format <char>', 'export format for site:export (pdf, docx, epub, zip, markdown, skeleton)')
+  .option('--export-format <char>', 'export format for site:export (pdf, docx, epub, html, zip, markdown, skeleton)')
   .option('--revision-id <char>', 'revision ID for site:revisions')
   .option('--restore', 'restore a revision (used with site:revisions)')
   .option('--target-path <char>', 'target subdirectory for files-upload')
@@ -216,7 +216,7 @@ async function main() {
   .option('--exclude <char>', 'comma-separated patterns to exclude from rsync')
   .option('--dry-run', 'perform rsync dry run')
   .option('--delete', 'delete extraneous files from destination')
-  .option('--export-format <char>', 'export format for site:export (pdf, docx, epub, zip, markdown, skeleton)')
+  .option('--export-format <char>', 'export format for site:export (pdf, docx, epub, html, zip, markdown, skeleton)')
   .option('--revision-id <char>', 'revision ID for site:revisions')
   .option('--restore', 'restore a revision (used with site:revisions)')
   .option('--target-path <char>', 'target subdirectory for files-upload')

--- a/src/docs/hax.1
+++ b/src/docs/hax.1
@@ -375,8 +375,8 @@ Install a skeleton template from a local JSON file
 .B hax site site:search --search "lesson"
 Search site text content and metadata fields
 .TP
-.B hax site site:search --search "video-player[src]" --search-selector
-Search site HTML content using selector mode
+.B hax site site:search --search "lesson" --search-field title,tags --search-limit 10
+Search site title and tags fields, limited to 10 matches
 .TP
 .B hax site node:add \--title "New Page" \--content "Page content"
 Add a new page to an existing site

--- a/src/lib/programs/site.js
+++ b/src/lib/programs/site.js
@@ -1868,8 +1868,8 @@ export async function siteCommandDetected(commandRun) {
           try {
             if (!commandRun.options.search) {
               commandRun.options.search = await p.text({
-                message: 'Search query',
-                placeholder: 'video-player[src]',
+                message: 'Search query (text search across site fields)',
+                placeholder: 'lesson',
                 validate: (value) => {
                   if (!value) {
                     return 'Search query is required';
@@ -1880,26 +1880,25 @@ export async function siteCommandDetected(commandRun) {
                 }
               });
             }
+            // v1 search contract (GET /v1/search) requires `q` and supports
+            // `fields` (CSV of: title,slug,description,tags,content,id,location),
+            // `sort`, and `page.limit`/`page.offset` pagination. The legacy v0
+            // params (searchCaseSensitive, searchSelector, searchMode) have no
+            // v1 equivalent: v1 search is always case-insensitive and only does
+            // text matching across fields (no selector/DOM-query mode). The
+            // --search-selector / --search-mode CLI flags are kept to avoid a
+            // breaking interface change but are intentionally not forwarded.
             let searchRouteParams = {
               siteName: activeHaxsite.name,
-              search: commandRun.options.search,
+              q: commandRun.options.search,
               user_token: "fakeToken",
               site_token: "fakeToken"
             };
             if (commandRun.options.searchField) {
-              searchRouteParams.searchField = commandRun.options.searchField;
-            }
-            if (commandRun.options.searchCaseSensitive) {
-              searchRouteParams.searchCaseSensitive = true;
+              searchRouteParams.fields = commandRun.options.searchField;
             }
             if (commandRun.options.searchLimit) {
-              searchRouteParams.searchLimit = commandRun.options.searchLimit;
-            }
-            if (commandRun.options.searchSelector) {
-              searchRouteParams.searchSelector = true;
-            }
-            if (commandRun.options.searchMode) {
-              searchRouteParams.searchMode = commandRun.options.searchMode;
+              searchRouteParams['page.limit'] = commandRun.options.searchLimit;
             }
             let searchRes = await invokeRoute(
               allRoutesLib.allRoutes.site.map.get['v1/search'],
@@ -2018,7 +2017,7 @@ export async function siteCommandDetected(commandRun) {
         case "site:export":
           try {
             let exportFormat = commandRun.options.exportFormat || commandRun.options.format;
-            const validExportFormats = ['pdf', 'docx', 'epub', 'zip', 'markdown', 'skeleton'];
+            const validExportFormats = ['pdf', 'docx', 'epub', 'html', 'zip', 'markdown', 'skeleton'];
             if (!exportFormat || !validExportFormats.includes(exportFormat)) {
               if (!commandRun.options.y) {
                 exportFormat = await p.select({
@@ -2027,13 +2026,14 @@ export async function siteCommandDetected(commandRun) {
                     { value: 'pdf', label: 'PDF' },
                     { value: 'docx', label: 'DOCX' },
                     { value: 'epub', label: 'EPUB' },
+                    { value: 'html', label: 'HTML' },
                     { value: 'zip', label: 'ZIP' },
                     { value: 'markdown', label: 'Markdown' },
                     { value: 'skeleton', label: 'Skeleton' },
                   ],
                 });
               } else {
-                log('Export format is required (pdf, docx, epub, zip, markdown, skeleton)', 'error');
+                log('Export format is required (pdf, docx, epub, html, zip, markdown, skeleton)', 'error');
                 break;
               }
             }
@@ -2046,8 +2046,14 @@ export async function siteCommandDetected(commandRun) {
                 log(`Export failed: ${typeof resp.res.data === 'string' ? resp.res.data : JSON.stringify(resp.res.data)}`, 'error');
                 break;
               }
-              const binaryFormats = ['pdf', 'docx', 'epub'];
-              if (binaryFormats.includes(exportFormat) && resp.res.data) {
+              // pdf/docx/epub return a binary buffer; html returns the full
+              // HTML document as a string. Both are file downloads the CLI
+              // writes directly to disk. zip/markdown/skeleton return a JSON
+              // export descriptor (data.export.href points at the real
+              // download) rather than the archive/markdown itself — printed
+              // below so the caller can follow the href.
+              const downloadFormats = ['pdf', 'docx', 'epub', 'html'];
+              if (downloadFormats.includes(exportFormat) && resp.res.data) {
                 let targetFile = commandRun.options.toFile;
                 if (!targetFile) {
                   targetFile = `${activeHaxsite.name}.${exportFormat}`;
@@ -2059,6 +2065,12 @@ export async function siteCommandDetected(commandRun) {
                 }
                 recipe.log(siteLoggingName, commandString(commandRun));
               } else {
+                // zip/markdown/skeleton: the v1 backend returns a JSON export
+                // descriptor (follow data.export.href for the actual file),
+                // not the archive/markdown itself.
+                if (!commandRun.options.quiet) {
+                  log(`${exportFormat} export returned a JSON descriptor (follow data.export.href for the actual file):`);
+                }
                 logStructuredOutput(commandRun, resp.res.data);
                 if (commandRun.options.toFile) {
                   fs.writeFileSync(commandRun.options.toFile, formatStructuredOutput(commandRun, resp.res.data));


### PR DESCRIPTION
## Summary

Fixes the create CLI's usage of the haxcms-nodejs v1 API surface, addressing the High (B4) and Low (F5) findings from the conformance audit.

## Changes

- **B4 (High):** `hax site:search` now sends v1 params (`q`, `fields`, `page.limit`) instead of the v0-style params (`search`, `searchField`, `searchLimit`, `searchCaseSensitive`, `searchSelector`, `searchMode`) that always 400'd against the v1 `/x/api/v1/search` endpoint. The `--search-selector`/`--search-mode`/`--search-case-sensitive` CLI flags are kept defined (to avoid a breaking interface change) but no longer forwarded.
- **F5 (Low):** `hax site:export` now supports the `html` format (added to `validExportFormats` and `downloadFormats`). For `zip`/`markdown`/`skeleton` formats (which return a JSON descriptor, not a file), the CLI now logs that the output is a descriptor with `data.export.href` pointing at the real download.
- Man page (`hax.1`) example updated from the misleading selector-mode syntax to v1 `fields`/`limit` syntax.

## Validation
- `node --check` on changed files → OK
- Smoke tests (ephemeral build, artifacts removed):
  - `hax site:search --search "the"` → 200, 7 results (was 400/no-op)
  - `hax site:search --search "the" --search-field title,content --search-limit 2` → fields=[title,content], count=2
  - `hax site:export --export-format html --to-file /tmp/x.html` → valid 10.8KB HTML file
  - `hax site:export --export-format markdown` → prints descriptor with href + supportedFormats (incl. html)

## Note
The v1 search backend has no selector/DOM-query mode — only case-insensitive text matching across fields. The CLI flags are retained to avoid breaking existing scripts but are no-ops against v1.

## Related
- Plan: https://app.warp.dev/drive/notebook/8q1JmPBd1jtecNAavo56eJ
- Conversation: https://app.warp.dev/conversation/f763bd0e-8f51-413f-bf9b-20eac83f721b

Co-Authored-By: Oz <oz-agent@warp.dev>